### PR TITLE
Add well-known path for purging

### DIFF
--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -100,5 +100,5 @@ jobs:
         uses: azure/CLI@v2
         with:
           inlineScript: |
-              az cdn endpoint purge --content-paths  "/*" --profile-name ${{ needs.build.outputs.cdn_profile }} --name ${{ needs.build.outputs.cdn_profile }} --resource-group ${{ needs.build.outputs.resource_group }}
+              az cdn endpoint purge --content-paths  "/*" "/.well-known/*" --profile-name ${{ needs.build.outputs.cdn_profile }} --name ${{ needs.build.outputs.cdn_profile }} --resource-group ${{ needs.build.outputs.resource_group }}
           


### PR DESCRIPTION
## Type of change
- [ ] Update security.txt file
- [ ] Update thanks.txt file
- [X] Bug fix to terraform, github actions workflow, or shell script
- [ ] Other (please explain below)

## Expected behaviour and actual behaviour (if relevant)
Purge content-path wildcard only purges the directory, not subdirectories.

## Steps to reproduce issue (if relevant)


## Link to bug report or github issue
