### PR TITLE
Fix http redirect rule by allowing http

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -145,7 +145,7 @@ resource "azurerm_cdn_endpoint" "vdp-cdn-endpoint" {
   profile_name        = azurerm_cdn_profile.vdp-cdn-profile.name
   resource_group_name = azurerm_resource_group.vulnerability-disclosure-program.name
   location            = azurerm_resource_group.vulnerability-disclosure-program.location
-  is_http_allowed     = false
+  is_http_allowed     = true
   is_https_allowed    = true
   tags                = local.tags
 


### PR DESCRIPTION
Redirection to https doesn't work if you disallow http

## Type of change
- [ ] Update security.txt file
- [ ] Update thanks.txt file
- [x] Bug fix to terraform, github actions workflow, or shell script
- [ ] Other (please explain below)

